### PR TITLE
changed build path to JSHint bin directly

### DIFF
--- a/JSHint.sublime-build
+++ b/JSHint.sublime-build
@@ -1,5 +1,5 @@
 {
-  "cmd": ["${packages}/JSHint/node_modules/.bin/jshint", "$file", "--reporter", "${packages}/JSHint/reporter.js"],
+  "cmd": ["${packages}/JSHint/node_modules/jshint/bin/hint", "$file", "--reporter", "${packages}/JSHint/reporter.js"],
 
   "file_regex": "file:\\s(.+)\\]",
   "line_regex": "(\\d+),(\\d+)",


### PR DESCRIPTION
Default install gave posix errors. First 'permission denied'. Fixed by chmod +x the .bin/jshint. Resulted in invalid executable posix error. Changed build path to 'node_modules/jshint/bin/hint'. Now works.
