### PR TITLE
Changing prereq

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The best JavaScript syntax checker: [JSHint](http://www.jshint.com/) for the best text editor: [Sublime Text 2](http://www.sublimetext.com/2)
 
-**Prerequisites:** [node-jshint](https://github.com/jshint/node-jshint) and [Sublime Package Control](http://wbond.net/sublime_packages/package_control/installation)
+**Prerequisites:** [jshint](https://github.com/jshint/jshint) and [Sublime Package Control](http://wbond.net/sublime_packages/package_control/installation)
 
 **Mac OS X:** Installing node with homebrew or macports is assumed. The path to jshint is hardcoded in this plugin as `/usr/local/bin:/opt/local/bin`. There is no reliable way to get the path from your environment.
 


### PR DESCRIPTION
Change the prerequisite to the main JSHint branch since node-jshint was merged in.
