### PR TITLE
Fixes Error 2 on Mac

### DIFF
--- a/JSHint.sublime-build
+++ b/JSHint.sublime-build
@@ -7,7 +7,7 @@
   "line_regex": "(\\d+),(\\d+)",
 
   "osx": {
-    "path": "/usr/local/bin:/opt/local/bin"
+    "path": "/user/local/share/npm/bin:/usr/local/bin:/opt/local/bin"
   },
 
   "windows": {


### PR DESCRIPTION
This fixed an issue that was not allowing the build when hitting `cmd` + `j` on Sublime Text 2 for Mac.

Related to issue #33 as well as closed issues #12 and #14.
