### PR TITLE
Fixes success message shown if there are warnings.

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -78,7 +78,7 @@ module.exports = {
       }
     }
 
-    if (!errorLength && !errorLength) {
+    if (!errorLength && !warningLength) {
       console.log('✓ JSHint PASSED! (no Errors or Warnings)');
     }
 


### PR DESCRIPTION
A previous commit had included a typo that caused a success message to be shown even if there was a warning. This fixes that.
