### PR TITLE
Tweak line_regex to allow reporting error in status bar

### DIFF
--- a/JSHint.sublime-build
+++ b/JSHint.sublime-build
@@ -4,7 +4,7 @@
   "cmd": ["jshint", "$file", "--reporter", "$packages/JSHint/reporter.js"],
 
   "file_regex": "JSHint: (.+)\\]",
-  "line_regex": "(\\d+),(\\d+)",
+  "line_regex": "(\\d+),(\\d+): (.*)$",
 
   "osx": {
     "path": "/usr/local/share/npm/bin:/usr/local/bin:/opt/local/bin"


### PR DESCRIPTION
`line_regex` (and `file_regex`) support an extra capture group for an error message, which will be displayed in the status bar when navigating between build results.  This change modifies the JSHint plugin's `line_regex` to capture the error message.
