### PR TITLE
Error codes on reporter.js for easier bypass

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -23,10 +23,11 @@ exports.reporter = function (errors, results) {
     }
 
     errors.forEach(function (result) {
-      var
-        error = result.error;
+      var error = result.error,
+          code = (error.code) ? ' (' + error.code + ')' : '';
 
-      buffer += numberWang((error.line + error.character.toString()).length) + ' ' + error.line + ',' + error.character + ':' + ' ' + error.reason + '\n';
+      buffer += numberWang((error.line + error.character.toString()).length) + ' ' + error.line + ',' + error.character + ':' + ' ' + error.reason + code + '\n';
+      
     });
 
     buffer += '\n✗ ' + errors.length + ' ' + title + ', double-click above, [F4] for next, [shift-F4] for previous.\n';


### PR DESCRIPTION
Hi

Sometimes it's useful to add a JSHint bypass on the code, with JSHint comments; if you want to write a bookmarket, for instance, JSHint will complain with this:

`Label 'javascript' looks like a javascript url.`

The the following line can be added to bypass it:

`/* jshint -W029 */`

However, to do that one must be able to read the **error code**. So, with this patch, the line above will look like:

`Label 'javascript' looks like a javascript url. (W029)`

Stating that it's a warning `W` and the error code `029`.

Hope you find it useful.

Thanks
