### PR TITLE
Rewrite JshintCommand entirely

### DIFF
--- a/JSHint.py
+++ b/JSHint.py
@@ -1,3 +1,5 @@
+import os
+
 import sublime
 import sublime_plugin
 
@@ -11,7 +13,7 @@ class JshintCommand(sublime_plugin.TextCommand):
                 "jshint",
                 filepath,
                 "--reporter",
-                packages + "/JSHint/reporter.js"
+                os.path.join(packages, "JSHint", "reporter.js")
             ],
             "file_regex": r"JSHint: (.+)\]",
             "line_regex": r"(\d+),(\d+): (.*)$"
@@ -19,8 +21,7 @@ class JshintCommand(sublime_plugin.TextCommand):
 
         if sublime.platform() == "windows":
             args['cmd'][0] += ".cmd"
-            args['cmd'][3] = args['cmd'][3].replace("/", "\\")
-        if sublime.platform() == "osx":
+        elif sublime.platform() == "osx":
             args['path'] = "/usr/local/share/npm/bin:/usr/local/bin:/opt/local/bin"
 
         self.view.window().run_command('exec', args)


### PR DESCRIPTION
This version does not require to change the currently active build system since it calls the build by itself. Changing the active build system is highly discouraged since this is something the user must change everytime after he uses this command if he uses a "real" build system for this file/project.

I wrote this for a user in IRC which was having the above mentioned issue so I personally didn't test it but according to him it worked (on OSX).
