### PR TITLE
Make jshint binary configurable

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -1,0 +1,4 @@
+{
+    // Executable to run to lint code.
+    "jshint_bin": "jshint"
+}

--- a/JSHint.py
+++ b/JSHint.py
@@ -6,14 +6,15 @@ import sublime_plugin
 
 class JshintCommand(sublime_plugin.TextCommand):
     def run(self, edit):
+        jshint_exe = self.view.settings().get('jshint_bin', 'jshint')
         filepath = self.view.file_name()
         packages = sublime.packages_path()
         args = {
             "cmd": [
-                "jshint",
+                jshint_exe,
                 filepath,
                 "--reporter",
-                os.path.join(packages, "JSHint", "reporter.js")
+                os.path.join(packages, "sublime-jshint", "reporter.js")
             ],
             "file_regex": r"JSHint: (.+)\]",
             "line_regex": r"(\d+),(\d+): (.*)$"

--- a/JSHint.py
+++ b/JSHint.py
@@ -14,7 +14,7 @@ class JshintCommand(sublime_plugin.TextCommand):
                 jshint_exe,
                 filepath,
                 "--reporter",
-                os.path.join(packages, "sublime-jshint", "reporter.js")
+                os.path.join(packages, "JSHint", "reporter.js")
             ],
             "file_regex": r"JSHint: (.+)\]",
             "line_regex": r"(\d+),(\d+): (.*)$"

--- a/JSHint.sublime-build
+++ b/JSHint.sublime-build
@@ -1,7 +1,7 @@
 {
   "selector": "source.js",
 
-  "cmd": ["jshint", "$file", "--reporter", "$packages/JSHint/reporter.js"],
+  "cmd": ["jshint", "$file", "--reporter", "$packages/sublime-jshint/reporter.js"],
 
   "file_regex": "JSHint: (.+)\\]",
   "line_regex": "(\\d+),(\\d+): (.*)$",
@@ -11,6 +11,6 @@
   },
 
   "windows": {
-    "cmd": ["jshint.cmd", "$file", "--reporter", "$packages\\JSHint\\reporter.js"]
+    "cmd": ["jshint.cmd", "$file", "--reporter", "$packages\\sublime-jshint\\reporter.js"]
   }
 }

--- a/JSHint.sublime-build
+++ b/JSHint.sublime-build
@@ -1,7 +1,7 @@
 {
   "selector": "source.js",
 
-  "cmd": ["jshint", "$file", "--reporter", "$packages/sublime-jshint/reporter.js"],
+  "cmd": ["jshint", "$file", "--reporter", "$packages/JSHint/reporter.js"],
 
   "file_regex": "JSHint: (.+)\\]",
   "line_regex": "(\\d+),(\\d+): (.*)$",
@@ -11,6 +11,6 @@
   },
 
   "windows": {
-    "cmd": ["jshint.cmd", "$file", "--reporter", "$packages\\sublime-jshint\\reporter.js"]
+    "cmd": ["jshint.cmd", "$file", "--reporter", "$packages\\JSHint\\reporter.js"]
   }
 }

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,10 +1,51 @@
-[{
-  "caption": "Tools",
-  "mnemonic": "t",
-  "id": "tools",
-  "children": [{
-    "id": "jshint",
-    "caption": "JSHint",
-    "command": "jshint"
-  }]
-}]
+[
+    {
+        "caption": "Tools",
+        "mnemonic": "t",
+        "id": "tools",
+        "children": [
+            {
+                "id": "jshint",
+                "caption": "JSHint",
+                "command": "jshint"
+            }
+        ]
+    },
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "JSHint",
+                        "children":
+                        [
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/sublime-jshint/Base File.sublime-settings"
+                                },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/Base File.sublime-settings"
+                                },
+                                "caption": "Settings – User"
+                            },
+                            { "caption": "-" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -30,7 +30,7 @@
                             {
                                 "command": "open_file", "args":
                                 {
-                                    "file": "${packages}/sublime-jshint/Base File.sublime-settings"
+                                    "file": "${packages}/JSHint/Base File.sublime-settings"
                                 },
                                 "caption": "Settings – Default"
                             },

--- a/reporter.js
+++ b/reporter.js
@@ -15,7 +15,11 @@ exports.reporter = function (errors, results) {
     return stayNumberWang;
   }
 
-  buffer += '[JSHint: ' + results[0].file + ']\n\n';
+  if (results && results[0] && results[0].file) {
+    buffer += '[JSHint: ' + results[0].file + ']\n\n';
+  } else {
+    buffer += '[JSX Transform]\n\n';
+  }
 
   if (errors.length) {
     if (errors.length > 1) {


### PR DESCRIPTION
Adds an option to use a custom binary. I'm using this for running `jsxhint`, since `SublimeLinter-jsxhint` just doesn't seem to work correctly, and I don't like using the `ignore` directive.

Issues with this PR:
1) This only makes the binary used in JSHint Text Command configurable. Not quite sure how to update the build command, but it's probably possible.
2) Didn't specify a specific User Preferences file for this package.

If this feature will be useful for anyone, I can address those two issues.
