### PR TITLE
Update .jshintrc for new JShint syntax's

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,7 @@
   "curly": true,
   "eqeqeq": true,
   "eqnull": false,
-  "es5": true,
+  "esversion": 5,
   "evil": false,
   "expr": false,
   "forin": true,


### PR DESCRIPTION
At new version JShint [es5](http://jshint.com/docs/options/#es5)  and [esnext](http://jshint.com/docs/options/#esnext) has been deprecated and will be removed in the next major release of JSHint. Use esversion: 5 (6) instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uipoet/sublime-jshint/77)
<!-- Reviewable:end -->
